### PR TITLE
Antlr updated & clean folder moved to not remove ExpressBaseListener ref

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -1,10 +1,11 @@
-SET ANTLR=java -jar C:\Javalib\antlr-4.7-complete.jar
+SET ANTLR=java -jar C:\Javalib\antlr-4.7.1-complete.jar
 SET CURR_DIR=%cd%
 SET GRAMMAR_IFC=%CURR_DIR%\Express.g4
 SET GRAMMAR_STEP=%CURR_DIR%\STEP.g4
 SET SCHEMA=%CURR_DIR%\IFC4.exp
 
 ::csharp:
+    rmdir /s /q .\src\antlr
 	%ANTLR% -Dlanguage=CSharp -package Express -o %CURR_DIR%\src\antlr %GRAMMAR_IFC%
 	%ANTLR% -Dlanguage=CSharp -package STEP -o %CURR_DIR%\lang\csharp\src\antlr %GRAMMAR_STEP%
 	dotnet build .\src\IFC-gen.csproj
@@ -12,6 +13,5 @@ SET SCHEMA=%CURR_DIR%\IFC4.exp
 
 ::clean:
 	rmdir /s /q .\lang\csharp\src\antlr
-	rmdir /s /q .\src\antlr
 	rmdir /s /q .\src\bin
 	rmdir /s /q .\src\obj


### PR DESCRIPTION
Updated make.bat to work with the latest version of Antlr download and to move the antlr folder cleanup to the beginning of the script so the references remain intact for the dotnet.sln references.