### PR TITLE
Don't mark as beta.

### DIFF
--- a/lang/csharp/src/IFC-dotnet.csproj
+++ b/lang/csharp/src/IFC-dotnet.csproj
@@ -15,7 +15,7 @@
     <RepositoryType>git</RepositoryType>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
-    <Version>0.1.0-beta1</Version>
+    <Version>0.1.0</Version>
     <PackageLicenseUrl>https://github.com/hypar-io/IFC-gen/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>IFC, AEC, Architecture, Structure, Engineering, Infrastructure</PackageTags>
   </PropertyGroup>

--- a/lang/csharp/tests/baselines/project.ifc
+++ b/lang/csharp/tests/baselines/project.ifc
@@ -6,11 +6,11 @@ FILE_DESCRIPTION(
 	'2;1');
 FILE_NAME(
     '../../../baselines/project.ifc',
-    '2018-12-20T14:12:43',
+    '2019-03-18T15:03:20',
     ('ikeough'),
     ('Test'),
     'IFC-dotnet',
-    '0.0.3.0',
+    '0.1.0.0',
 	'None');
 FILE_SCHEMA (('IFC4'));
 ENDSEC;
@@ -20,9 +20,9 @@ DATA;
 #3 = IFCPERSON('ikeough', 'Ian', 'Keough', $, $, $, (#1), $);
 #4 = IFCORGANIZATION('Test', 'Test', 'A test organization for model creation.', $, (#2));
 #5 = IFCORGANIZATION($, 'IFC-dotnet', $, $, $);
-#6 = IFCAPPLICATION(#5, '0.0.3.0', 'IFC-dotnet', 'IFC-dotnet');
+#6 = IFCAPPLICATION(#5, '0.1.0.0', 'IFC-dotnet', 'IFC-dotnet');
 #7 = IFCPERSONANDORGANIZATION(#3, #4, $);
-#8 = IFCOWNERHISTORY(#7, #6, .READWRITE., .NOCHANGE., $, $, $, 1545343663);
+#8 = IFCOWNERHISTORY(#7, #6, .READWRITE., .NOCHANGE., $, $, $, 1552949060);
 #9 = IFCSIUNIT(*, .LENGTHUNIT., .EXA., .METRE.);
 #10 = IFCSIUNIT(*, .AREAUNIT., .EXA., .SQUARE_METRE.);
 #11 = IFCSIUNIT(*, .VOLUMEUNIT., .EXA., .CUBIC_METRE.);
@@ -36,6 +36,6 @@ DATA;
 #19 = IFCDIMENSIONALEXPONENTS(0, 0, 0, 0, 0, 0, 0);
 #20 = IFCCONVERSIONBASEDUNIT(#19, .PLANEANGLEUNIT., 'DEGREE', #18);
 #21 = IFCUNITASSIGNMENT((#9, #10, #11, #12, #13, #14, #15, #16, #17, #20));
-#22 = IFCPROJECT('0tVF2CYZH1o9Fswp_uDrnZ', #8, 'Test Project', 'A test project for the Elements API.', $, $, $, $, #21);
+#22 = IFCPROJECT('3_xp$GgDrAGhuiAhnHyh6t', #8, 'Test Project', 'A test project for the Elements API.', $, $, $, $, #21);
 ENDSEC;
 END-ISO-10303-21;


### PR DESCRIPTION
Marking the project as beta means you can't include it in a non-beta project.