### PR TITLE
Don't mark as beta.

### DIFF
--- a/lang/csharp/src/IFC-dotnet.csproj
+++ b/lang/csharp/src/IFC-dotnet.csproj
@@ -15,7 +15,7 @@
     <RepositoryType>git</RepositoryType>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
-    <Version>0.1.0-beta1</Version>
+    <Version>0.1.0</Version>
     <PackageLicenseUrl>https://github.com/hypar-io/IFC-gen/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>IFC, AEC, Architecture, Structure, Engineering, Infrastructure</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
Marking the project as beta means you can't include it in a non-beta project.