### PR TITLE
Fix semicolon at inverseRedef in Express.g4

### DIFF
--- a/grammar/Express.g4
+++ b/grammar/Express.g4
@@ -378,7 +378,7 @@ inverseDef
 	;
 
 inverseRedef
-	: attrRef ';' inverseType FOR attrRef ';'
+	: attrRef ':' inverseType FOR attrRef ';'
 	;
 
 inverseType


### PR DESCRIPTION
The grammar file is invalid for inverseRedef rule -- it should be a colon (`:`) instead of a semi-colon (`;`).